### PR TITLE
Fixing exported typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.6.5",
+    "@auth0/auth0-spa-js": "^1.7.0-beta.5",
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developertown/auth0-react-spa-provider",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/reducer.test.ts
+++ b/src/__tests__/reducer.test.ts
@@ -1,3 +1,4 @@
+import * as Auth0 from "@auth0/auth0-spa-js";
 import { auth0Loaded, handleRedirectCallbackAction, loginWithPopupAction } from "../actions";
 import { auth0ProviderStateReducer } from "../reducer";
 import {
@@ -10,16 +11,14 @@ import {
   UnauthenticatedState,
 } from "../types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createFakeAuth0Client = (): any => {
-  return {
-    loginWithRedirect: jest.fn(),
-    getTokenWithPopup: jest.fn(),
-    getTokenSilently: jest.fn(),
-    getIdTokenClaims: jest.fn(),
-    logout: jest.fn(),
-  };
-};
+jest.mock("@auth0/auth0-spa-js");
+
+const createFakeAuth0Client = (): Auth0.Auth0Client =>
+  new Auth0.Auth0Client({
+    domain: "",
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    client_id: "",
+  });
 
 const createInitialState = (): LoadingState => ({
   loading: true,
@@ -30,7 +29,9 @@ const createInitialState = (): LoadingState => ({
   handlingRedirect: false,
 });
 
-const createFakeUnauthenticatedState = (): UnauthenticatedState => ({
+const createFakeUnauthenticatedState = (
+  auth0Client: Auth0.Auth0Client = createFakeAuth0Client(),
+): UnauthenticatedState => ({
   isAuthenticated: false,
   loading: false,
   loginWithPopup: jest.fn(),
@@ -38,15 +39,12 @@ const createFakeUnauthenticatedState = (): UnauthenticatedState => ({
   handlingRedirect: false,
   user: undefined,
   popupOpen: false,
-  // eslint-disable-next-line @typescript-eslint/camelcase,@typescript-eslint/ban-ts-ignore
-  // @ts-ignore
-  auth0Client: {
-    loginWithRedirect: jest.fn(),
-    getTokenWithPopup: jest.fn(),
-    getTokenSilently: jest.fn(),
-    getIdTokenClaims: jest.fn(),
-    logout: jest.fn(),
-  }, //new Auth0Client({ domain: "xyz", client_id: "pdq" }),
+  auth0Client,
+  loginWithRedirect: auth0Client.loginWithRedirect.bind(auth0Client),
+  getTokenWithPopup: auth0Client.getTokenWithPopup.bind(auth0Client),
+  getTokenSilently: auth0Client.getTokenSilently.bind(auth0Client),
+  getIdTokenClaims: auth0Client.getIdTokenClaims.bind(auth0Client),
+  logout: auth0Client.logout.bind(auth0Client),
 });
 
 const createHandlingRedirectState = (): HandlingRedirectState =>

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,4 +1,4 @@
-import createAuth0Client from "@auth0/auth0-spa-js";
+import createAuth0Client, { PopupConfigOptions, PopupLoginOptions, RedirectLoginResult } from "@auth0/auth0-spa-js";
 import Auth0Client from "@auth0/auth0-spa-js/dist/typings/Auth0Client";
 import React, { Dispatch, Reducer, useEffect, useReducer } from "react";
 import { useAsync, useAsyncFn, useLocation } from "react-use";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import "@auth0/auth0-spa-js";
+import { Auth0ClientOptions } from "@auth0/auth0-spa-js";
 import Auth0Client from "@auth0/auth0-spa-js/dist/typings/Auth0Client";
 import { History } from "history";
 import { createContext, Dispatch, ReactElement } from "react";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "dist"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,12 @@
 # yarn lockfile v1
 
 
-"@auth0/auth0-spa-js@^1.6.5":
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-1.6.5.tgz#4679a609bbdb4c86866a1600c7b21b637a8cf765"
-  integrity sha512-pS5jF5DAHXeDssN9cJwOqAbgLYhJaXD2EBgeXkjfB3rrNcd7bYC9rOGckRTqyS2k2A05/N2aaRFnju81AgSDgQ==
+"@auth0/auth0-spa-js@^1.7.0-beta.5":
+  version "1.7.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-1.7.0-beta.5.tgz#72a70bf8f91dd68e1440731d3616aa2577d6a430"
+  integrity sha512-Lm3gAXWqvosW/3v1vNHCXDsJTQ1dhdyN2FebRL3LUbXCSM/Yo+fBdGxGfXlMrWGVayDxAsDd6xpYGduCf0NDYA==
   dependencies:
+    abortcontroller-polyfill "^1.4.0"
     browser-tabs-lock "^1.2.7"
     core-js "^3.6.4"
     es-cookie "^1.3.2"
@@ -1359,6 +1360,11 @@ abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+
+abortcontroller-polyfill@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz#0d5eb58e522a461774af8086414f68e1dda7a6c4"
+  integrity sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==
 
 acorn-globals@^4.3.2:
   version "4.3.4"


### PR DESCRIPTION
The published `1.6.5` auth0 sdk has some issues in the way it exports types.  This bumps up to the `1.7` beta sdk for now to take advantage of improved typing support.